### PR TITLE
use pse associated image in all case

### DIFF
--- a/Action/GoogleProductEventListener.php
+++ b/Action/GoogleProductEventListener.php
@@ -149,21 +149,21 @@ class GoogleProductEventListener implements EventSubscriberInterface
         $lang =  $event->getLang();
         $currency = $event->getCurrency();
 
+        //Use pse associated image if exist instead of product image
+        $pseImage = ProductImageQuery::create()
+            ->useProductSaleElementsProductImageQuery()
+            ->filterByProductSaleElementsId($productSaleElements->getId())
+            ->endUse()
+            ->findOne();
+        if ($pseImage !== null) {
+            $imagePseEvent = $this->googleShoppingHandler->createProductImageEvent($pseImage);
+            $event->getDispatcher()->dispatch(TheliaEvents::IMAGE_PROCESS, $imagePseEvent);
+            $event->setImagePath($imagePseEvent->getFileUrl());
+        }
+
         //If we have multiple pse for one product manage attribute
         if ($itemGroupId !== null) {
             $googleProduct->setItemGroupId($itemGroupId);
-
-            //Use pse associated image if exist instead of product image
-            $pseImage = ProductImageQuery::create()
-                ->useProductSaleElementsProductImageQuery()
-                ->filterByProductSaleElementsId($productSaleElements->getId())
-                ->endUse()
-                ->findOne();
-            if ($pseImage !== null) {
-                $imagePseEvent = $this->googleShoppingHandler->createProductImageEvent($pseImage);
-                $event->getDispatcher()->dispatch(TheliaEvents::IMAGE_PROCESS, $imagePseEvent);
-                $event->setImagePath($imagePseEvent->getFileUrl());
-            }
 
             $colorAttributeId = GoogleShopping::getConfigValue('attribute_color');
             $sizeAttributeId = GoogleShopping::getConfigValue('attribute_size');


### PR DESCRIPTION
(not only on color or size attribute)
resolve issue #15 